### PR TITLE
fix twacs call & add separate character cutoffs for words and urls

### DIFF
--- a/search_api.py
+++ b/search_api.py
@@ -37,7 +37,6 @@ class GnipSearchAPI:
         twitter_parser.add_argument("-n", "--results-max", dest="max", default=100, 
                 help="Maximum results to return (default 100)")
         self.options = twitter_parser.parse_args()
-        #self.twitter_parser = TwacsCSV(",",False, True, False, True, False, False, False)
         self.twitter_parser = TwacsCSV(",", False, False, True, False, True, False, False, False)
         DATE_INDEX = 1
         TEXT_INDEX = 2


### PR DESCRIPTION
1) twacs constructor didn't reflect addition of keypath option.

2) charUpperCutoff was set to 11 for the tokenized wordcount use_case. Unwound URLs are nearly always longer than this, which led to them not being included in the frequency counter.
