### PR TITLE
Publisher error in v2

### DIFF
--- a/search/api.py
+++ b/search/api.py
@@ -252,8 +252,6 @@ class Query(object):
                     'query': pt_filter
             }
         self.rule_payload["maxResults"] = int(max_results)
-        if not self.search_v2:
-            self.rule_payload["publisher"] = "twitter"
         if start:
             self.rule_payload["fromDate"] = self.fromDate
         if end:


### PR DESCRIPTION
Removing the if not syntax for self-serach_v2 corrects a 422 response
code, alleviating the following error message for Search API
(Full-Archive).

ERROR Message: There were errors processing your request: Unknown
parameter:'publisher'