### PR TITLE
Decode data from locally-written binary files

### DIFF
--- a/search/api.py
+++ b/search/api.py
@@ -200,7 +200,7 @@ class Query(object):
             for file_name in self.paged_file_list:
                 with codecs.open(file_name,"rb") as f:
                     for res in f:
-                        rec = json.loads(res.strip())
+                        rec = json.loads(res.decode('utf-8').strip())
                         t = datetime.datetime.strptime(rec["timePeriod"], TIME_FORMAT_SHORT)
                         yield [rec["timePeriod"], rec["count"], t]
         else:
@@ -218,7 +218,7 @@ class Query(object):
             for file_name in self.paged_file_list:
                 with codecs.open(file_name,"rb") as f:
                     for res in f:
-                        yield json.loads(res)
+                        yield json.loads(res.decode('utf-8'))
         else:
             for res in self.rec_dict_list:
                 yield res


### PR DESCRIPTION
In the current implementation, the data is written to local files in binary mode. As a result, we have to decode them to strings before attempting to parse them as JSON. 

I'm not sure if this is Python 3 specific, but I ran into this error using this code with version 3.5.1. A quick test with 2.7.9 shows that this PR is compatible with that version, as well.